### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     
         > linux：
         
-            cp cpp/linux/* /usr/local/lib/
+            cp cpp/lib/linux/* /usr/local/lib/
             cp cpp/buildcpp/linux/libtradeplugin.so /usr/local/lib/
             cp cpp/buildcpp/linux/libquoteplugin.so /usr/local/lib/
             


### PR DESCRIPTION
please help review and merge if applicable..

seems linux lib is located within  cpp/lib/linux, instead of cpp/linux

===================================================
~/github/pink-lucifer/xtp_api_java$ ll -rt cpp 
total 32
-rw-r--r-- 1 ebyf-lw ebyf-lw 7558 4月  24 15:11 CMakeLists.txt
drwxr-xr-x 6 ebyf-lw ebyf-lw 4096 4月  24 15:11 buildcpp/
drwxr-xr-x 4 ebyf-lw ebyf-lw 4096 4月  24 15:11 dependsLibSrc/
drwxr-xr-x 6 ebyf-lw ebyf-lw 4096 4月  24 15:11 lib/
drwxr-xr-x 3 ebyf-lw ebyf-lw 4096 4月  24 15:11 src/
drwxr-xr-x 6 ebyf-lw ebyf-lw 4096 4月  24 15:11 ./
drwxr-xr-x 9 ebyf-lw ebyf-lw 4096 4月  24 15:13 ../
~/github/pink-lucifer/xtp_api_java$ ll -rt  cpp/lib
total 24
drwxr-xr-x 2 ebyf-lw ebyf-lw 4096 4月  24 15:11 linux/
drwxr-xr-x 3 ebyf-lw ebyf-lw 4096 4月  24 15:11 win32/
drwxr-xr-x 2 ebyf-lw ebyf-lw 4096 4月  24 15:11 macosx/
drwxr-xr-x 3 ebyf-lw ebyf-lw 4096 4月  24 15:11 win64/
drwxr-xr-x 6 ebyf-lw ebyf-lw 4096 4月  24 15:11 ./
drwxr-xr-x 6 ebyf-lw ebyf-lw 4096 4月  24 15:11 ../
